### PR TITLE
fix: Replace all instances of a filename

### DIFF
--- a/tasks/uniqueify.js
+++ b/tasks/uniqueify.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
     };
 
     var textReplace = function(src, find, replace, filePath) {
-        var newText = src.replace(find, replace);
+        var newText = src.replace(new RegExp(find, 'g'), replace);
         if (newText != src) {
             grunt.log.write(filePath + ' : ' + find + ' ').ok(replace);
         }


### PR DESCRIPTION
Currently, only the first instance of a filename is replaced in each `options.replaceSrc` file

This change makes the task replace all instances of a filename in each replaceSrc file